### PR TITLE
Keyword or name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    ext.kotlin_version = '1.2.71'
+    ext.kotlin_version = '1.3.0'
     ext.dokka_version = '0.9.17'
     ext.ktlint_version = '0.28.0'
 

--- a/jipp-core/bin/genTypes.py
+++ b/jipp-core/bin/genTypes.py
@@ -762,8 +762,8 @@ def fix_ktypes(type, syntax, name, group_name = ''):
                     type['kdoc'] = real_type['kdoc']
 
             elif syntax == 'keyword | name':
-                intro = "KeywordType("
-                type['ktype'] = "String"
+                intro = "KeywordOrNameType("
+                type['ktype'] = "KeywordOrName"
                 type['kdoc'] = "May contain any keyword from [" + camel_class(real_type['name']) + "] or a name."
         elif syntax == 'keyword':
             # No definition was given so fall back to Keyword

--- a/jipp-core/build.gradle
+++ b/jipp-core/build.gradle
@@ -184,10 +184,10 @@ def customizePom(pom) {
             resolveStrategy = DELEGATE_FIRST
 
             description 'Parse/build IPP packets'
-            name project.name
+            name = project.name
             url 'https://github.com/HPInc/jipp'
             organization {
-                name 'HP Development Company, L.P.'
+                name = 'HP Development Company, L.P.'
                 url 'https://github.com/HPInc'
             }
             issueManagement {
@@ -196,7 +196,7 @@ def customizePom(pom) {
             }
             licenses {
                 license {
-                    name 'MIT'
+                    name = 'MIT'
                     url 'https://github.com/HPInc/jipp/blob/master/LICENSE.md'
                     distribution 'repo'
                 }
@@ -208,7 +208,7 @@ def customizePom(pom) {
             }
             developers {
                 developer {
-                    name 'Glade Diviney'
+                    name = 'Glade Diviney'
                 }
             }
         }

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/AttributeGroup.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/AttributeGroup.kt
@@ -52,9 +52,13 @@ class AttributeGroup(
     fun <T : Any> getValues(type: AttributeType<T>): List<T> =
         get(type) ?: listOf()
 
-    /** Return all values found having this attribute type. */
+    /** Return the string form of any values present for this attribute [type]. */
     fun <T : Any> getStrings(type: AttributeType<T>): List<String> =
         get(type)?.strings() ?: listOf()
+
+    /** Return the string form (or null) of the first value present for this attribute [type]. */
+    fun <T : Any> getString(type: AttributeType<T>): String? =
+        get(type)?.strings()?.firstOrNull()
 
     /** Return the attribute as conforming to the supplied attribute type. */
     operator fun <T : Any> get(type: AttributeType<T>): Attribute<T>? =

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/AttributeGroup.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/AttributeGroup.kt
@@ -137,6 +137,7 @@ class AttributeGroup(
                     writeValueBytes(it.value)
                 }),
                 KeywordType.codec,
+                KeywordOrNameType.codec, // Must follow both Keyword and Name
                 UriType.codec,
                 codec({ it.isCharString }, { tag ->
                     // Handle other harder-to-type values here:

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/IppPacket.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/IppPacket.kt
@@ -15,6 +15,7 @@ import java.io.OutputStream
 /**
  * An IPP packet consisting of header information and zero or more attribute groups.
  */
+@Suppress("TooManyFunctions")
 data class IppPacket constructor(
     val versionNumber: Int = DEFAULT_VERSION_NUMBER,
     val code: Int,
@@ -53,11 +54,17 @@ data class IppPacket constructor(
     fun <T : Any> getValues(groupDelimiter: Tag, type: AttributeType<T>): List<T> =
         this[groupDelimiter]?.get(type) ?: listOf()
 
-    fun <T : Any> getStrings(groupDelimiter: Tag, type: AttributeType<T>): List<String> =
-        this[groupDelimiter]?.get(type)?.strings() ?: listOf()
-
+    /** Return the first value within the group of [groupDelimiter] and [type]. */
     fun <T : Any> getValue(groupDelimiter: Tag, type: AttributeType<T>): T? =
         this[groupDelimiter]?.get(type)?.get(0)
+
+    /** Return the string form of any attribute values within the group of [groupDelimiter] and [type]. */
+    fun <T : Any> getStrings(groupDelimiter: Tag, type: AttributeType<T>): List<String> =
+        this[groupDelimiter]?.getStrings(type) ?: listOf()
+
+    /** Return the string form of the first attribute value within the group of [groupDelimiter] and [type]. */
+    fun <T : Any> getString(groupDelimiter: Tag, type: AttributeType<T>): String? =
+        this[groupDelimiter]?.getString(type)
 
     /** Make a copy of this packet but replace with the supplied attribute groups */
     fun withAttributeGroups(attributeGroups: List<AttributeGroup>): IppPacket =

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/KeyValues.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/KeyValues.kt
@@ -4,6 +4,7 @@
 package com.hp.jipp.encoding
 
 /** A map of keys to values where keys and values are both strings. */
+@Suppress("ConstructorParameterNaming") // _encoding is weird but it's supposed to be
 class KeyValues(
     /** Pairs of key/values. */
     val pairs: Map<String, String> = linkedMapOf(),

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/KeywordOrName.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/KeywordOrName.kt
@@ -1,0 +1,34 @@
+// Copyright 2017 HP Development Company, L.P.
+// SPDX-License-Identifier: MIT
+
+package com.hp.jipp.encoding
+
+import java.lang.IllegalArgumentException
+
+/**
+ * Describes an object which may contain either a name [Name] or a keyword [String].
+ *
+ * See [RFC8011 Section 5.1.3](https://tools.ietf.org/html/rfc8011#section-5.1.3).
+ */
+data class KeywordOrName constructor(val name: Name?, val keyword: String?) : TaggedValue(), Stringable {
+
+    /** Construct a [KeywordOrName] containing only a keyword. */
+    constructor(keyword: String) : this(null, keyword)
+
+    /** Construct a [KeywordOrName] containing only a name. */
+    constructor(name: Name) : this(name, null)
+
+    init {
+        name ?: keyword ?: throw IllegalArgumentException("both .name and .keyword are null")
+        if (name != null && keyword != null) throw IllegalArgumentException("both .name and .keyword are present")
+    }
+
+    override val tag: Tag = name?.tag ?: Tag.keyword
+
+    override val value = name ?: keyword!!
+
+    override fun asString() = name?.asString() ?: keyword!!
+
+    override fun toString() =
+        name?.toString() ?: keyword!!
+}

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/KeywordOrNameType.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/KeywordOrNameType.kt
@@ -1,0 +1,44 @@
+// Copyright 2017 HP Development Company, L.P.
+// SPDX-License-Identifier: MIT
+
+package com.hp.jipp.encoding
+
+/**
+ * An attribute type for `name` or `keyword` values.
+ *
+ * See [RFC8011 Section 5.1.3](https://tools.ietf.org/html/rfc8011#section-5.1.3).
+ */
+class KeywordOrNameType(override val name: String) : AttributeType<KeywordOrName> {
+
+    override fun coerce(value: Any): KeywordOrName? =
+        when (value) {
+            is KeywordOrName -> value
+            is Name -> KeywordOrName(value)
+            is String -> KeywordOrName(value)
+            else -> null
+        }
+
+    /** Return an attribute containing values as keywords .*/
+    fun of(vararg keywords: String) = of(keywords.map { KeywordOrName(it) })
+
+    /** Return an attribute containing values as keywords. */
+    fun of(vararg names: Name) = of(names.map { KeywordOrName(it) })
+
+    /** Return an attribute containing values interpreted as keywords. */
+    fun ofKeywords(values: List<String>) = of(values.map { KeywordOrName(Name(it)) })
+
+    /** Return an attribute containing values as text strings (without language). */
+    fun ofNames(values: List<String>) = of(values.map { KeywordOrName(Name(it)) })
+
+    companion object {
+        val codec = AttributeGroup.codec<KeywordOrName>({ false }, {
+            throw IllegalArgumentException("This codec is not used for reading")
+        }, {
+            if (NameType.codec.handlesTag(it.tag)) {
+                NameType.codec.writeValue(this, it.name!!)
+            } else {
+                KeywordType.codec.writeValue(this, it.keyword!!)
+            }
+        })
+    }
+}

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/MediaSizes.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/MediaSizes.kt
@@ -7,7 +7,7 @@ import java.util.regex.Pattern
 import com.hp.jipp.model.MediaCol
 
 object MediaSizes {
-    private val WIDTH_HEIGHT = Pattern.compile(
+    private val widthHeightPattern = Pattern.compile(
         "_([0-9]+(\\.[0-9]+)?)?x([0-9]+(\\.[0-9]+)?)([a-z]+)?$")
     private const val WIDTH_AT = 1
     private const val HEIGHT_AT = 3
@@ -20,7 +20,7 @@ object MediaSizes {
     /** Convert a media name containing dimensions into a [MediaCol.MediaSize] object, if possible. */
     @JvmStatic
     fun parse(mediaName: String): MediaCol.MediaSize? {
-        val matches = WIDTH_HEIGHT.matcher(mediaName)
+        val matches = widthHeightPattern.matcher(mediaName)
         if (!matches.find() || matches.groupCount() < WIDTH_HEIGHT_DIMENSION_COUNT) {
             // No way to guess media size from name, not enough parts.
             return null

--- a/jipp-core/src/main/java/com/hp/jipp/model/CoverBack.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/CoverBack.kt
@@ -20,7 +20,7 @@ constructor(
     /** May contain any keyword from [CoverType]. */
     var coverType: String? = null,
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null
 ) : AttributeCollection {
 
@@ -52,7 +52,7 @@ constructor(
     /** Types for each member attribute. */
     object Types {
         val coverType = KeywordType(Name.coverType)
-        val media = KeywordType(Name.media)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/CoverFront.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/CoverFront.kt
@@ -20,7 +20,7 @@ constructor(
     /** May contain any keyword from [CoverType]. */
     var coverType: String? = null,
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null
 ) : AttributeCollection {
 
@@ -52,7 +52,7 @@ constructor(
     /** Types for each member attribute. */
     object Types {
         val coverType = KeywordType(Name.coverType)
-        val media = KeywordType(Name.media)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/FinishingsCol.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/FinishingsCol.kt
@@ -22,10 +22,10 @@ constructor(
     var coating: Coating? = null,
     var covering: Covering? = null,
     /** May contain any keyword from [FinishingTemplate] or a name. */
-    var finishingTemplate: String? = null,
+    var finishingTemplate: KeywordOrName? = null,
     var folding: List<Folding>? = null,
     /** May contain any keyword from [ImpositionTemplate] or a name. */
-    var impositionTemplate: String? = null,
+    var impositionTemplate: KeywordOrName? = null,
     var laminating: Laminating? = null,
     var mediaSheetsSupported: IntRange? = null,
     var mediaSize: MediaSize? = null,
@@ -100,9 +100,9 @@ constructor(
         val binding = Binding.Type(Name.binding)
         val coating = Coating.Type(Name.coating)
         val covering = Covering.Type(Name.covering)
-        val finishingTemplate = KeywordType(Name.finishingTemplate)
+        val finishingTemplate = KeywordOrNameType(Name.finishingTemplate)
         val folding = Folding.Type(Name.folding)
-        val impositionTemplate = KeywordType(Name.impositionTemplate)
+        val impositionTemplate = KeywordOrNameType(Name.impositionTemplate)
         val laminating = Laminating.Type(Name.laminating)
         val mediaSheetsSupported = IntRangeType(Name.mediaSheetsSupported)
         val mediaSize = MediaSize.Type(Name.mediaSize)
@@ -140,7 +140,7 @@ constructor(
     data class Baling
     constructor(
         /** May contain any keyword from [BalingType] or a name. */
-        var balingType: String? = null,
+        var balingType: KeywordOrName? = null,
         /** May contain any keyword from [BalingWhen]. */
         var balingWhen: String? = null
     ) : AttributeCollection {
@@ -169,7 +169,7 @@ constructor(
 
         /** Types for each member attribute. */
         object Types {
-            val balingType = KeywordType(Name.balingType)
+            val balingType = KeywordOrNameType(Name.balingType)
             val balingWhen = KeywordType(Name.balingWhen)
         }
 
@@ -192,7 +192,7 @@ constructor(
         /** May contain any keyword from [BindingReferenceEdge]. */
         var bindingReferenceEdge: String? = null,
         /** May contain any keyword from [BindingType] or a name. */
-        var bindingType: String? = null
+        var bindingType: KeywordOrName? = null
     ) : AttributeCollection {
 
         /** Construct an empty [Binding]. */
@@ -220,7 +220,7 @@ constructor(
         /** Types for each member attribute. */
         object Types {
             val bindingReferenceEdge = KeywordType(Name.bindingReferenceEdge)
-            val bindingType = KeywordType(Name.bindingType)
+            val bindingType = KeywordOrNameType(Name.bindingType)
         }
 
         /** Defines types for each member of [Binding] */
@@ -242,7 +242,7 @@ constructor(
         /** May contain any keyword from [CoatingSides]. */
         var coatingSides: String? = null,
         /** May contain any keyword from [CoatingType] or a name. */
-        var coatingType: String? = null
+        var coatingType: KeywordOrName? = null
     ) : AttributeCollection {
 
         /** Construct an empty [Coating]. */
@@ -270,7 +270,7 @@ constructor(
         /** Types for each member attribute. */
         object Types {
             val coatingSides = KeywordType(Name.coatingSides)
-            val coatingType = KeywordType(Name.coatingType)
+            val coatingType = KeywordOrNameType(Name.coatingType)
         }
 
         /** Defines types for each member of [Coating] */
@@ -290,7 +290,7 @@ constructor(
     data class Covering
     constructor(
         /** May contain any keyword from [CoveringName] or a name. */
-        var coveringName: String? = null
+        var coveringName: KeywordOrName? = null
     ) : AttributeCollection {
 
         /** Construct an empty [Covering]. */
@@ -314,7 +314,7 @@ constructor(
 
         /** Types for each member attribute. */
         object Types {
-            val coveringName = KeywordType(Name.coveringName)
+            val coveringName = KeywordOrNameType(Name.coveringName)
         }
 
         /** Defines types for each member of [Covering] */
@@ -391,7 +391,7 @@ constructor(
         /** May contain any keyword from [LaminatingSides]. */
         var laminatingSides: String? = null,
         /** May contain any keyword from [LaminatingType] or a name. */
-        var laminatingType: String? = null
+        var laminatingType: KeywordOrName? = null
     ) : AttributeCollection {
 
         /** Construct an empty [Laminating]. */
@@ -419,7 +419,7 @@ constructor(
         /** Types for each member attribute. */
         object Types {
             val laminatingSides = KeywordType(Name.laminatingSides)
-            val laminatingType = KeywordType(Name.laminatingType)
+            val laminatingType = KeywordOrNameType(Name.laminatingType)
         }
 
         /** Defines types for each member of [Laminating] */
@@ -613,7 +613,7 @@ constructor(
         /** May contain any keyword from [TrimmingReferenceEdge]. */
         var trimmingReferenceEdge: String? = null,
         /** May contain any keyword from [TrimmingType] or a name. */
-        var trimmingType: String? = null,
+        var trimmingType: KeywordOrName? = null,
         /** May contain any keyword from [TrimmingWhen]. */
         var trimmingWhen: String? = null
     ) : AttributeCollection {
@@ -650,7 +650,7 @@ constructor(
         object Types {
             val trimmingOffset = IntType(Name.trimmingOffset)
             val trimmingReferenceEdge = KeywordType(Name.trimmingReferenceEdge)
-            val trimmingType = KeywordType(Name.trimmingType)
+            val trimmingType = KeywordOrNameType(Name.trimmingType)
             val trimmingWhen = KeywordType(Name.trimmingWhen)
         }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/InsertSheet.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/InsertSheet.kt
@@ -20,7 +20,7 @@ constructor(
     var insertAfterPageNumber: Int? = null,
     var insertCount: Int? = null,
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null
 ) : AttributeCollection {
 
@@ -56,7 +56,7 @@ constructor(
     object Types {
         val insertAfterPageNumber = IntType(Name.insertAfterPageNumber)
         val insertCount = IntType(Name.insertCount)
-        val media = KeywordType(Name.media)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/JobAccountingSheets.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/JobAccountingSheets.kt
@@ -18,11 +18,11 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class JobAccountingSheets
 constructor(
     /** May contain any keyword from [OutputBin] or a name. */
-    var jobAccountingOutputBin: String? = null,
+    var jobAccountingOutputBin: KeywordOrName? = null,
     /** May contain any keyword from [JobAccountingSheetsType] or a name. */
-    var jobAccountingSheetsType: String? = null,
+    var jobAccountingSheetsType: KeywordOrName? = null,
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null
 ) : AttributeCollection {
 
@@ -56,9 +56,9 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val jobAccountingOutputBin = KeywordType(Name.jobAccountingOutputBin)
-        val jobAccountingSheetsType = KeywordType(Name.jobAccountingSheetsType)
-        val media = KeywordType(Name.media)
+        val jobAccountingOutputBin = KeywordOrNameType(Name.jobAccountingOutputBin)
+        val jobAccountingSheetsType = KeywordOrNameType(Name.jobAccountingSheetsType)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/JobErrorSheet.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/JobErrorSheet.kt
@@ -17,11 +17,11 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class JobErrorSheet
 constructor(
     /** May contain any keyword from [JobErrorSheetType] or a name. */
-    var jobErrorSheetType: String? = null,
+    var jobErrorSheetType: KeywordOrName? = null,
     /** May contain any keyword from [JobErrorSheetWhen]. */
     var jobErrorSheetWhen: String? = null,
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null
 ) : AttributeCollection {
 
@@ -55,9 +55,9 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val jobErrorSheetType = KeywordType(Name.jobErrorSheetType)
+        val jobErrorSheetType = KeywordOrNameType(Name.jobErrorSheetType)
         val jobErrorSheetWhen = KeywordType(Name.jobErrorSheetWhen)
-        val media = KeywordType(Name.media)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/JobPresetsSupported.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/JobPresetsSupported.kt
@@ -17,7 +17,7 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class JobPresetsSupported
 constructor(
     /** May contain any keyword from [PresetName] or a name. */
-    var presetName: String? = null
+    var presetName: KeywordOrName? = null
 ) : AttributeCollection {
 
     /** Construct an empty [JobPresetsSupported]. */
@@ -41,7 +41,7 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val presetName = KeywordType(Name.presetName)
+        val presetName = KeywordOrNameType(Name.presetName)
     }
 
     /** Defines types for each member of [JobPresetsSupported] */

--- a/jipp-core/src/main/java/com/hp/jipp/model/JobSheetsCol.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/JobSheetsCol.kt
@@ -18,9 +18,9 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class JobSheetsCol
 constructor(
     /** May contain any keyword from [JobSheet] or a name. */
-    var jobSheets: String? = null,
+    var jobSheets: KeywordOrName? = null,
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null
 ) : AttributeCollection {
 
@@ -51,8 +51,8 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val jobSheets = KeywordType(Name.jobSheets)
-        val media = KeywordType(Name.media)
+        val jobSheets = KeywordOrNameType(Name.jobSheets)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/JobTriggersSupported.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/JobTriggersSupported.kt
@@ -17,7 +17,7 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class JobTriggersSupported
 constructor(
     /** May contain any keyword from [PresetName] or a name. */
-    var presetName: String? = null
+    var presetName: KeywordOrName? = null
 ) : AttributeCollection {
 
     /** Construct an empty [JobTriggersSupported]. */
@@ -41,7 +41,7 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val presetName = KeywordType(Name.presetName)
+        val presetName = KeywordOrNameType(Name.presetName)
     }
 
     /** Defines types for each member of [JobTriggersSupported] */

--- a/jipp-core/src/main/java/com/hp/jipp/model/MaterialsCol.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/MaterialsCol.kt
@@ -34,7 +34,7 @@ constructor(
     var materialShellThickness: Int? = null,
     var materialTemperature: IntOrIntRange? = null,
     /** May contain any keyword from [MaterialType] or a name. */
-    var materialType: String? = null
+    var materialType: KeywordOrName? = null
 ) : AttributeCollection {
 
     /** Construct an empty [MaterialsCol]. */
@@ -110,7 +110,7 @@ constructor(
         val materialRateUnits = KeywordType(Name.materialRateUnits)
         val materialShellThickness = IntType(Name.materialShellThickness)
         val materialTemperature = IntOrIntRangeType(Name.materialTemperature)
-        val materialType = KeywordType(Name.materialType)
+        val materialType = KeywordOrNameType(Name.materialType)
     }
 
     /** Defines types for each member of [MaterialsCol] */

--- a/jipp-core/src/main/java/com/hp/jipp/model/MediaCol.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/MediaCol.kt
@@ -19,37 +19,37 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class MediaCol
 constructor(
     /** May contain any keyword from [MediaBackCoating] or a name. */
-    var mediaBackCoating: String? = null,
+    var mediaBackCoating: KeywordOrName? = null,
     var mediaBottomMargin: Int? = null,
     /** May contain any keyword from [MediaColor] or a name. */
-    var mediaColor: String? = null,
+    var mediaColor: KeywordOrName? = null,
     /** May contain any keyword from [MediaBackCoating] or a name. */
-    var mediaFrontCoating: String? = null,
+    var mediaFrontCoating: KeywordOrName? = null,
     /** May contain any keyword from [MediaGrain] or a name. */
-    var mediaGrain: String? = null,
+    var mediaGrain: KeywordOrName? = null,
     var mediaHoleCount: Int? = null,
     var mediaInfo: String? = null,
     /** May contain any keyword from [Media] or a name. */
-    var mediaKey: String? = null,
+    var mediaKey: KeywordOrName? = null,
     var mediaLeftMargin: Int? = null,
     var mediaOrderCount: Int? = null,
     /** May contain any keyword from [MediaPrePrinted] or a name. */
-    var mediaPrePrinted: String? = null,
+    var mediaPrePrinted: KeywordOrName? = null,
     /** May contain any keyword from [MediaRecycled] or a name. */
-    var mediaRecycled: String? = null,
+    var mediaRecycled: KeywordOrName? = null,
     var mediaRightMargin: Int? = null,
     var mediaSize: MediaSize? = null,
     /** May contain any keyword from [Media] or a name. */
-    var mediaSizeName: String? = null,
+    var mediaSizeName: KeywordOrName? = null,
     /** May contain any keyword from [MediaSource] or a name. */
-    var mediaSource: String? = null,
+    var mediaSource: KeywordOrName? = null,
     var mediaSourceProperties: MediaSourceProperties? = null,
     var mediaThickness: Int? = null,
     /** May contain any keyword from [MediaTooth] or a name. */
-    var mediaTooth: String? = null,
+    var mediaTooth: KeywordOrName? = null,
     var mediaTopMargin: Int? = null,
     /** May contain any keyword from [MediaType] or a name. */
-    var mediaType: String? = null,
+    var mediaType: KeywordOrName? = null,
     var mediaWeightMetric: Int? = null
 ) : AttributeCollection {
 
@@ -137,27 +137,27 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val mediaBackCoating = KeywordType(Name.mediaBackCoating)
+        val mediaBackCoating = KeywordOrNameType(Name.mediaBackCoating)
         val mediaBottomMargin = IntType(Name.mediaBottomMargin)
-        val mediaColor = KeywordType(Name.mediaColor)
-        val mediaFrontCoating = KeywordType(Name.mediaFrontCoating)
-        val mediaGrain = KeywordType(Name.mediaGrain)
+        val mediaColor = KeywordOrNameType(Name.mediaColor)
+        val mediaFrontCoating = KeywordOrNameType(Name.mediaFrontCoating)
+        val mediaGrain = KeywordOrNameType(Name.mediaGrain)
         val mediaHoleCount = IntType(Name.mediaHoleCount)
         val mediaInfo = TextType(Name.mediaInfo)
-        val mediaKey = KeywordType(Name.mediaKey)
+        val mediaKey = KeywordOrNameType(Name.mediaKey)
         val mediaLeftMargin = IntType(Name.mediaLeftMargin)
         val mediaOrderCount = IntType(Name.mediaOrderCount)
-        val mediaPrePrinted = KeywordType(Name.mediaPrePrinted)
-        val mediaRecycled = KeywordType(Name.mediaRecycled)
+        val mediaPrePrinted = KeywordOrNameType(Name.mediaPrePrinted)
+        val mediaRecycled = KeywordOrNameType(Name.mediaRecycled)
         val mediaRightMargin = IntType(Name.mediaRightMargin)
         val mediaSize = MediaSize.Type(Name.mediaSize)
-        val mediaSizeName = KeywordType(Name.mediaSizeName)
-        val mediaSource = KeywordType(Name.mediaSource)
+        val mediaSizeName = KeywordOrNameType(Name.mediaSizeName)
+        val mediaSource = KeywordOrNameType(Name.mediaSource)
         val mediaSourceProperties = MediaSourceProperties.Type(Name.mediaSourceProperties)
         val mediaThickness = IntType(Name.mediaThickness)
-        val mediaTooth = KeywordType(Name.mediaTooth)
+        val mediaTooth = KeywordOrNameType(Name.mediaTooth)
         val mediaTopMargin = IntType(Name.mediaTopMargin)
-        val mediaType = KeywordType(Name.mediaType)
+        val mediaType = KeywordOrNameType(Name.mediaType)
         val mediaWeightMetric = IntType(Name.mediaWeightMetric)
     }
 

--- a/jipp-core/src/main/java/com/hp/jipp/model/ProofPrint.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/ProofPrint.kt
@@ -17,7 +17,7 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class ProofPrint
 constructor(
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null,
     var proofPrintCopies: Int? = null
 ) : AttributeCollection {
@@ -49,7 +49,7 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val media = KeywordType(Name.media)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
         val proofPrintCopies = IntType(Name.proofPrintCopies)
     }

--- a/jipp-core/src/main/java/com/hp/jipp/model/SeparatorSheets.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/SeparatorSheets.kt
@@ -18,7 +18,7 @@ import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
 data class SeparatorSheets
 constructor(
     /** May contain any keyword from [Media] or a name. */
-    var media: String? = null,
+    var media: KeywordOrName? = null,
     var mediaCol: MediaCol? = null,
     /** May contain any keyword from [SeparatorSheetsType]. */
     var separatorSheetsType: List<String>? = null
@@ -51,7 +51,7 @@ constructor(
 
     /** Types for each member attribute. */
     object Types {
-        val media = KeywordType(Name.media)
+        val media = KeywordOrNameType(Name.media)
         val mediaCol = MediaCol.Type(Name.mediaCol)
         val separatorSheetsType = KeywordType(Name.separatorSheetsType)
     }

--- a/jipp-core/src/main/java/com/hp/jipp/model/Types.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/Types.kt
@@ -35,7 +35,7 @@ object Types {
      * [PWG5100.1](https://ftp.pwg.org/pub/pwg/candidates/cs-ippfinishings10-20010205-5100.1.pdf).
      * May contain any keyword from [BalingType] or a name.
      */
-    @JvmField val balingTypeSupported = KeywordType("baling-type-supported")
+    @JvmField val balingTypeSupported = KeywordOrNameType("baling-type-supported")
     /**
      * "baling-when-supported" as defined in:
      * [PWG5100.1](https://ftp.pwg.org/pub/pwg/candidates/cs-ippfinishings10-20010205-5100.1.pdf).
@@ -80,7 +80,7 @@ object Types {
      * [PWG5100.1](https://ftp.pwg.org/pub/pwg/candidates/cs-ippfinishings10-20010205-5100.1.pdf).
      * May contain any keyword from [CoatingType] or a name.
      */
-    @JvmField val coatingTypeSupported = KeywordType("coating-type-supported")
+    @JvmField val coatingTypeSupported = KeywordOrNameType("coating-type-supported")
     /**
      * "color-supported" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
@@ -209,7 +209,7 @@ object Types {
      * [PWG5100.1](https://ftp.pwg.org/pub/pwg/candidates/cs-ippfinishings10-20010205-5100.1.pdf).
      * May contain any keyword from [CoveringName] or a name.
      */
-    @JvmField val coveringNameSupported = KeywordType("covering-name-supported")
+    @JvmField val coveringNameSupported = KeywordOrNameType("covering-name-supported")
     /**
      * "current-page-order" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
@@ -780,25 +780,25 @@ object Types {
      * [PWG5100.5](https://ftp.pwg.org/pub/pwg/candidates/cs-ippdocobject10-20031031-5100.5.pdf).
      * May contain any keyword from [ImpositionTemplate] or a name.
      */
-    @JvmField val impositionTemplate = KeywordType("imposition-template")
+    @JvmField val impositionTemplate = KeywordOrNameType("imposition-template")
     /**
      * "imposition-template-actual" as defined in:
      * [PWG5100.8](https://ftp.pwg.org/pub/pwg/candidates/cs-ippactuals10-20030313-5100.8.pdf).
      * May contain any keyword from [ImpositionTemplate] or a name.
      */
-    @JvmField val impositionTemplateActual = KeywordType("imposition-template-actual")
+    @JvmField val impositionTemplateActual = KeywordOrNameType("imposition-template-actual")
     /**
      * "imposition-template-default" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [ImpositionTemplate] or a name.
      */
-    @JvmField val impositionTemplateDefault = KeywordType("imposition-template-default")
+    @JvmField val impositionTemplateDefault = KeywordOrNameType("imposition-template-default")
     /**
      * "imposition-template-supported" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [ImpositionTemplate] or a name.
      */
-    @JvmField val impositionTemplateSupported = KeywordType("imposition-template-supported")
+    @JvmField val impositionTemplateSupported = KeywordOrNameType("imposition-template-supported")
     /**
      * "impressions" as defined in:
      * [PWG5100.5](https://ftp.pwg.org/pub/pwg/candidates/cs-ippdocobject10-20031031-5100.5.pdf).
@@ -981,25 +981,25 @@ object Types {
      * [PWG5100.16](https://ftp.pwg.org/pub/pwg/candidates/cs-ipptrans10-20131108-5100.16.pdf).
      * May contain any keyword from [JobAccountType] or a name.
      */
-    @JvmField val jobAccountType = KeywordType("job-account-type")
+    @JvmField val jobAccountType = KeywordOrNameType("job-account-type")
     /**
      * "job-account-type-actual" as defined in:
      * [PWG5100.16](https://ftp.pwg.org/pub/pwg/candidates/cs-ipptrans10-20131108-5100.16.pdf).
      * May contain any keyword from [JobAccountType] or a name.
      */
-    @JvmField val jobAccountTypeActual = KeywordType("job-account-type-actual")
+    @JvmField val jobAccountTypeActual = KeywordOrNameType("job-account-type-actual")
     /**
      * "job-account-type-default" as defined in:
      * [PWG5100.16](https://ftp.pwg.org/pub/pwg/candidates/cs-ipptrans10-20131108-5100.16.pdf).
      * May contain any keyword from [JobAccountType] or a name.
      */
-    @JvmField val jobAccountTypeDefault = KeywordType("job-account-type-default")
+    @JvmField val jobAccountTypeDefault = KeywordOrNameType("job-account-type-default")
     /**
      * "job-account-type-supported" as defined in:
      * [PWG5100.16](https://ftp.pwg.org/pub/pwg/candidates/cs-ipptrans10-20131108-5100.16.pdf).
      * May contain any keyword from [JobAccountType] or a name.
      */
-    @JvmField val jobAccountTypeSupported = KeywordType("job-account-type-supported")
+    @JvmField val jobAccountTypeSupported = KeywordOrNameType("job-account-type-supported")
     /**
      * "job-accounting-sheets" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf),
@@ -1149,19 +1149,19 @@ object Types {
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [JobDelayOutputUntil] or a name.
      */
-    @JvmField val jobDelayOutputUntil = KeywordType("job-delay-output-until")
+    @JvmField val jobDelayOutputUntil = KeywordOrNameType("job-delay-output-until")
     /**
      * "job-delay-output-until-default" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [JobDelayOutputUntil] or a name.
      */
-    @JvmField val jobDelayOutputUntilDefault = KeywordType("job-delay-output-until-default")
+    @JvmField val jobDelayOutputUntilDefault = KeywordOrNameType("job-delay-output-until-default")
     /**
      * "job-delay-output-until-supported" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [JobDelayOutputUntil] or a name.
      */
-    @JvmField val jobDelayOutputUntilSupported = KeywordType("job-delay-output-until-supported")
+    @JvmField val jobDelayOutputUntilSupported = KeywordOrNameType("job-delay-output-until-supported")
     /**
      * "job-delay-output-until-time" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
@@ -1282,25 +1282,25 @@ object Types {
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [JobHoldUntil] or a name.
      */
-    @JvmField val jobHoldUntil = KeywordType("job-hold-until")
+    @JvmField val jobHoldUntil = KeywordOrNameType("job-hold-until")
     /**
      * "job-hold-until-actual" as defined in:
      * [PWG5100.8](https://ftp.pwg.org/pub/pwg/candidates/cs-ippactuals10-20030313-5100.8.pdf).
      * May contain any keyword from [JobHoldUntil] or a name.
      */
-    @JvmField val jobHoldUntilActual = KeywordType("job-hold-until-actual")
+    @JvmField val jobHoldUntilActual = KeywordOrNameType("job-hold-until-actual")
     /**
      * "job-hold-until-default" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [JobHoldUntil] or a name.
      */
-    @JvmField val jobHoldUntilDefault = KeywordType("job-hold-until-default")
+    @JvmField val jobHoldUntilDefault = KeywordOrNameType("job-hold-until-default")
     /**
      * "job-hold-until-supported" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [JobHoldUntil] or a name.
      */
-    @JvmField val jobHoldUntilSupported = KeywordType("job-hold-until-supported")
+    @JvmField val jobHoldUntilSupported = KeywordOrNameType("job-hold-until-supported")
     /**
      * "job-hold-until-time" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
@@ -1491,13 +1491,13 @@ object Types {
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [JobPasswordEncryption] or a name.
      */
-    @JvmField val jobPasswordEncryption = KeywordType("job-password-encryption")
+    @JvmField val jobPasswordEncryption = KeywordOrNameType("job-password-encryption")
     /**
      * "job-password-encryption-supported" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [JobPasswordEncryption] or a name.
      */
-    @JvmField val jobPasswordEncryptionSupported = KeywordType("job-password-encryption-supported")
+    @JvmField val jobPasswordEncryptionSupported = KeywordOrNameType("job-password-encryption-supported")
     /**
      * "job-password-length-supported" as defined in:
      * [IPPWG20160229-1](https://ftp.pwg.org/pub/pwg/ipp/wd/wp-job-password-repertoire-20160101.pdf).
@@ -1508,13 +1508,13 @@ object Types {
      * [IPPWG20160229-1](https://ftp.pwg.org/pub/pwg/ipp/wd/wp-job-password-repertoire-20160101.pdf).
      * May contain any keyword from [JobPasswordRepertoireSupported] or a name.
      */
-    @JvmField val jobPasswordRepertoireConfigured = KeywordType("job-password-repertoire-configured")
+    @JvmField val jobPasswordRepertoireConfigured = KeywordOrNameType("job-password-repertoire-configured")
     /**
      * "job-password-repertoire-supported" as defined in:
      * [IPPWG20160229-1](https://ftp.pwg.org/pub/pwg/ipp/wd/wp-job-password-repertoire-20160101.pdf).
      * May contain any keyword from [JobPasswordRepertoireSupported] or a name.
      */
-    @JvmField val jobPasswordRepertoireSupported = KeywordType("job-password-repertoire-supported")
+    @JvmField val jobPasswordRepertoireSupported = KeywordOrNameType("job-password-repertoire-supported")
     /**
      * "job-password-supported" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
@@ -1643,13 +1643,13 @@ object Types {
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [JobSheet] or a name.
      */
-    @JvmField val jobSheets = KeywordType("job-sheets")
+    @JvmField val jobSheets = KeywordOrNameType("job-sheets")
     /**
      * "job-sheets-actual" as defined in:
      * [PWG5100.8](https://ftp.pwg.org/pub/pwg/candidates/cs-ippactuals10-20030313-5100.8.pdf).
      * May contain any keyword from [JobSheet] or a name.
      */
-    @JvmField val jobSheetsActual = KeywordType("job-sheets-actual")
+    @JvmField val jobSheetsActual = KeywordOrNameType("job-sheets-actual")
     /**
      * "job-sheets-col" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf),
@@ -1677,13 +1677,13 @@ object Types {
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [JobSheet] or a name.
      */
-    @JvmField val jobSheetsDefault = KeywordType("job-sheets-default")
+    @JvmField val jobSheetsDefault = KeywordOrNameType("job-sheets-default")
     /**
      * "job-sheets-supported" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [JobSheet] or a name.
      */
-    @JvmField val jobSheetsSupported = KeywordType("job-sheets-supported")
+    @JvmField val jobSheetsSupported = KeywordOrNameType("job-sheets-supported")
     /**
      * "job-spooling-supported" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
@@ -1763,7 +1763,7 @@ object Types {
      * [PWG5100.1](https://ftp.pwg.org/pub/pwg/candidates/cs-ippfinishings10-20010205-5100.1.pdf).
      * May contain any keyword from [LaminatingType] or a name.
      */
-    @JvmField val laminatingTypeSupported = KeywordType("laminating-type-supported")
+    @JvmField val laminatingTypeSupported = KeywordOrNameType("laminating-type-supported")
     /**
      * "last-document" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
@@ -1879,19 +1879,19 @@ object Types {
      * [PWG5100.5](https://ftp.pwg.org/pub/pwg/candidates/cs-ippdocobject10-20031031-5100.5.pdf).
      * May contain any keyword from [Media] or a name.
      */
-    @JvmField val media = KeywordType("media")
+    @JvmField val media = KeywordOrNameType("media")
     /**
      * "media-actual" as defined in:
      * [PWG5100.8](https://ftp.pwg.org/pub/pwg/candidates/cs-ippactuals10-20030313-5100.8.pdf).
      * May contain any keyword from [Media] or a name.
      */
-    @JvmField val mediaActual = KeywordType("media-actual")
+    @JvmField val mediaActual = KeywordOrNameType("media-actual")
     /**
      * "media-back-coating-supported" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [MediaBackCoating] or a name.
      */
-    @JvmField val mediaBackCoatingSupported = KeywordType("media-back-coating-supported")
+    @JvmField val mediaBackCoatingSupported = KeywordOrNameType("media-back-coating-supported")
     /**
      * "media-bottom-margin-supported" as defined in:
      * [PWG5100.13](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf).
@@ -1939,25 +1939,25 @@ object Types {
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [MediaColor] or a name.
      */
-    @JvmField val mediaColorSupported = KeywordType("media-color-supported")
+    @JvmField val mediaColorSupported = KeywordOrNameType("media-color-supported")
     /**
      * "media-default" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [Media] or a name.
      */
-    @JvmField val mediaDefault = KeywordType("media-default")
+    @JvmField val mediaDefault = KeywordOrNameType("media-default")
     /**
      * "media-front-coating-supported" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [MediaBackCoating] or a name.
      */
-    @JvmField val mediaFrontCoatingSupported = KeywordType("media-front-coating-supported")
+    @JvmField val mediaFrontCoatingSupported = KeywordOrNameType("media-front-coating-supported")
     /**
      * "media-grain-supported" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [MediaGrain] or a name.
      */
-    @JvmField val mediaGrainSupported = KeywordType("media-grain-supported")
+    @JvmField val mediaGrainSupported = KeywordOrNameType("media-grain-supported")
     /**
      * "media-hole-count-supported" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
@@ -1983,7 +1983,7 @@ object Types {
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [Media] or a name.
      */
-    @JvmField val mediaKeySupported = KeywordType("media-key-supported")
+    @JvmField val mediaKeySupported = KeywordOrNameType("media-key-supported")
     /**
      * "media-left-margin-supported" as defined in:
      * [PWG5100.13](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf).
@@ -1999,7 +1999,7 @@ object Types {
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [MediaPrePrinted] or a name.
      */
-    @JvmField val mediaPrePrintedSupported = KeywordType("media-pre-printed-supported")
+    @JvmField val mediaPrePrintedSupported = KeywordOrNameType("media-pre-printed-supported")
     /**
      * "media-ready" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
@@ -2010,7 +2010,7 @@ object Types {
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [MediaRecycled] or a name.
      */
-    @JvmField val mediaRecycledSupported = KeywordType("media-recycled-supported")
+    @JvmField val mediaRecycledSupported = KeywordOrNameType("media-recycled-supported")
     /**
      * "media-right-margin-supported" as defined in:
      * [PWG5100.13](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf).
@@ -2046,13 +2046,13 @@ object Types {
      * [PWG5100.13](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf).
      * May contain any keyword from [MediaSource] or a name.
      */
-    @JvmField val mediaSourceSupported = KeywordType("media-source-supported")
+    @JvmField val mediaSourceSupported = KeywordOrNameType("media-source-supported")
     /**
      * "media-supported" as defined in:
      * [RFC8011](http://www.iana.org/go/rfc8011).
      * May contain any keyword from [Media] or a name.
      */
-    @JvmField val mediaSupported = KeywordType("media-supported")
+    @JvmField val mediaSupported = KeywordOrNameType("media-supported")
     /**
      * "media-thickness-supported" as defined in:
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
@@ -2063,7 +2063,7 @@ object Types {
      * [PWG5100.11](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext10-20101030-5100.11.pdf).
      * May contain any keyword from [MediaTooth] or a name.
      */
-    @JvmField val mediaToothSupported = KeywordType("media-tooth-supported")
+    @JvmField val mediaToothSupported = KeywordOrNameType("media-tooth-supported")
     /**
      * "media-top-margin-supported" as defined in:
      * [PWG5100.13](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf).
@@ -2074,7 +2074,7 @@ object Types {
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
      * May contain any keyword from [MediaType] or a name.
      */
-    @JvmField val mediaTypeSupported = KeywordType("media-type-supported")
+    @JvmField val mediaTypeSupported = KeywordOrNameType("media-type-supported")
     /**
      * "media-weight-metric-supported" as defined in:
      * [PWG5100.3](https://ftp.pwg.org/pub/pwg/candidates/cs-ippprodprint10-20010212-5100.3.pdf).
@@ -2457,26 +2457,26 @@ object Types {
      * [PWG5100.2](https://ftp.pwg.org/pub/pwg/candidates/cs-ippoutputbin10-20010207-5100.2.pdf).
      * May contain any keyword from [OutputBin] or a name.
      */
-    @JvmField val outputBin = KeywordType("output-bin")
+    @JvmField val outputBin = KeywordOrNameType("output-bin")
     /**
      * "output-bin-actual" as defined in:
      * [PWG5100.5](https://ftp.pwg.org/pub/pwg/candidates/cs-ippdocobject10-20031031-5100.5.pdf),
      * [PWG5100.8](https://ftp.pwg.org/pub/pwg/candidates/cs-ippactuals10-20030313-5100.8.pdf).
      * May contain any keyword from [OutputBin] or a name.
      */
-    @JvmField val outputBinActual = KeywordType("output-bin-actual")
+    @JvmField val outputBinActual = KeywordOrNameType("output-bin-actual")
     /**
      * "output-bin-default" as defined in:
      * [PWG5100.2](https://ftp.pwg.org/pub/pwg/candidates/cs-ippoutputbin10-20010207-5100.2.pdf).
      * May contain any keyword from [OutputBin] or a name.
      */
-    @JvmField val outputBinDefault = KeywordType("output-bin-default")
+    @JvmField val outputBinDefault = KeywordOrNameType("output-bin-default")
     /**
      * "output-bin-supported" as defined in:
      * [PWG5100.2](https://ftp.pwg.org/pub/pwg/candidates/cs-ippoutputbin10-20010207-5100.2.pdf).
      * May contain any keyword from [OutputBin] or a name.
      */
-    @JvmField val outputBinSupported = KeywordType("output-bin-supported")
+    @JvmField val outputBinSupported = KeywordOrNameType("output-bin-supported")
     /**
      * "output-device" as defined in:
      * [PWG5100.7](https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobext10-20031031-5100.7.pdf).

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/CollectionTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/CollectionTest.java
@@ -19,7 +19,7 @@ public class CollectionTest {
 
     private FinishingsCol finishingsCol = new FinishingsCol();
     {
-        finishingsCol.setCovering(new FinishingsCol.Covering(CoveringName.preCut));
+        finishingsCol.setCovering(new FinishingsCol.Covering(new KeywordOrName(CoveringName.preCut)));
         finishingsCol.setFolding(Arrays.asList(
                 new FinishingsCol.Folding(FoldingDirection.inward, 22, FoldingReferenceEdge.bottom),
                 new FinishingsCol.Folding(FoldingDirection.outward, 66, FoldingReferenceEdge.left)));

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/KeywordOrNameTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/KeywordOrNameTest.java
@@ -27,4 +27,10 @@ public class KeywordOrNameTest {
                 new KeywordOrName(new Name("name"))));
         assertEquals(Arrays.asList("keyword", "name"), attribute.strings());
     }
+
+    @Test
+    public void keywords() throws IOException {
+        Attribute<KeywordOrName> attribute = cycle(type, type.of("keyword", "keyword2"));
+        assertEquals(Arrays.asList("keyword", "keyword2"), attribute.strings());
+    }
 }

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/KeywordOrNameTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/KeywordOrNameTest.java
@@ -1,0 +1,30 @@
+package com.hp.jipp.encoding;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.hp.jipp.encoding.Cycler.cycle;
+import static org.junit.Assert.assertEquals;
+
+public class KeywordOrNameTest {
+    private KeywordOrNameType type = new KeywordOrNameType("media");
+
+    @Test
+    public void simple() throws IOException {
+        Attribute<KeywordOrName> attribute = cycle(type, type.of(
+                new KeywordOrName("keyword"),
+                new KeywordOrName(new Name("name"))));
+        assertEquals("\"name\" (name)", attribute.get(1).toString());
+        assertEquals("keyword", attribute.get(0).toString());
+    }
+
+    @Test
+    public void strings() throws IOException {
+        Attribute<KeywordOrName> attribute = cycle(type, type.of(
+                new KeywordOrName("keyword"),
+                new KeywordOrName(new Name("name"))));
+        assertEquals(Arrays.asList("keyword", "name"), attribute.strings());
+    }
+}


### PR DESCRIPTION
### Fix #11 
* Support setting the tumble and duplex booleans sent over PWG-Raster

### Fix #31
* Introduces `KeywordOrName` type. Unfortunately this will make some common APIs a bit more awkward as you will have to dig through the N-way type to get to either the underlying Keyword or Name.