### PR TITLE
No need to send the document on Get-Printer-Attributes operation

### DIFF
--- a/sample/jprint/src/main/java/sample/Main.java
+++ b/sample/jprint/src/main/java/sample/Main.java
@@ -43,7 +43,7 @@ class Main {
                         requestedAttributes.of(documentFormatSupported.getName())));
 
         System.out.println("Sending " + attributeRequest.prettyPrint(100, "  "));
-        IppPacketData request = new IppPacketData(attributeRequest, new FileInputStream(inputFile));
+        IppPacketData request = new IppPacketData(attributeRequest);
         IppPacketData response = transport.sendData(uri, request);
         System.out.println("Received: " + response.getPacket().prettyPrint(100, "  "));
 


### PR DESCRIPTION
No need to send the document on Get-Printer-Attributes operation

Signed-off-by: PK Søreide <per.kristian.soreide@gmail.com>