### PR TITLE
IppPacket builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,9 @@ dependencies {
 3. Use the transport to send and receive `IppPacket` objects, e.g.:
 ```
 URI uri = URI.create("http://192.168.1.100:631/ipp/print");
-IppPacket printRequest = new IppPacket(Operation.printJob, 123,
-        groupOf(operationAttributes,
-                attributesCharset.of("utf-8"),
-                attributesNaturalLanguage.of("en"),
-                printerUri.of(uri),
-                requestingUserName.of("user"),
-                documentFormat.of("application/octet-stream")));
+IppPacket printRequest = IppPacket.printJobRequest(uri)
+        .addOperationAttribute(documentFormat.of("application/pdf")))
+        .build();
 transport.sendData(uri, new IppPacketData(printRequest, new FileInputStream(inputFile)));
 ```
 

--- a/jipp-core/src/main/java/com/hp/jipp/dsl/dsl.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/dsl/dsl.kt
@@ -3,9 +3,13 @@
 
 package com.hp.jipp.dsl
 
-import com.hp.jipp.encoding.* // ktlint-disable no-wildcard-imports
+import com.hp.jipp.encoding.AttributeGroup
 import com.hp.jipp.encoding.AttributeGroup.Companion.mutableGroupOf
+import com.hp.jipp.encoding.IppPacket
+import com.hp.jipp.encoding.IppPacket.Companion.DEFAULT_REQUEST_ID
 import com.hp.jipp.encoding.IppPacket.Companion.DEFAULT_VERSION_NUMBER
+import com.hp.jipp.encoding.MutableAttributeGroup
+import com.hp.jipp.encoding.Tag
 import com.hp.jipp.model.Operation
 import com.hp.jipp.model.Status
 
@@ -16,9 +20,10 @@ import com.hp.jipp.model.Status
  * [DEFAULT_VERSION_NUMBER] and its `requestId` is set to [DEFAULT_REQUEST_ID].
  */
 @Suppress("ClassName", "ClassNaming")
+@Deprecated("Use IppPacket builders")
 object ippPacket {
     /** The default request ID (1001), which can be overridden with `requestId = 123` */
-    const val DEFAULT_REQUEST_ID = 1001
+    @Suppress("DEPRECATION")
     operator fun invoke(
         operation: Operation,
         requestId: Int = DEFAULT_REQUEST_ID,
@@ -28,6 +33,7 @@ object ippPacket {
         build()
     }
 
+    @Suppress("DEPRECATION")
     operator fun invoke(
         status: Status,
         requestId: Int = DEFAULT_REQUEST_ID,
@@ -42,10 +48,11 @@ object ippPacket {
  * Context for building an IPP [IppPacket].
  */
 @IppDslMarker
+@Deprecated("Use IppPacket builders")
 class InPacket constructor(
     var versionNumber: Int = DEFAULT_VERSION_NUMBER,
     var code: Int,
-    var requestId: Int = ippPacket.DEFAULT_REQUEST_ID
+    var requestId: Int = DEFAULT_REQUEST_ID
 ) {
     private val groups = ArrayList<MutableAttributeGroup>()
 
@@ -108,6 +115,7 @@ class InPacket constructor(
 
 /** DSL for defining an [AttributeGroup]. */
 @Suppress("ClassName", "ClassNaming")
+@Deprecated("Use IppPacket builders")
 object group {
     operator fun invoke(tag: Tag, func: MutableAttributeGroup.() -> Unit) =
         mutableGroupOf(tag).apply { func() }.toGroup()

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/AttributeGroup.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/AttributeGroup.kt
@@ -42,6 +42,10 @@ interface AttributeGroup : PrettyPrintable, List<Attribute<*>> {
         printer.close()
     }
 
+    /** Return a new [AttributeGroup] with additional attributes added to the end. */
+    operator fun plus(attributes: List<Attribute<*>>): AttributeGroup =
+        AttributeGroupImpl(tag, this + attributes)
+
     /** Return a copy of this attribute group in mutable form. */
     fun toMutable(): MutableAttributeGroup =
         mutableGroupOf(tag, this)

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/IppPacket.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/IppPacket.kt
@@ -123,7 +123,7 @@ data class IppPacket constructor(
 
         init {
             // All packets must have an operation attributes group with these initial attributes
-            addOperationAttributes(
+            putOperationAttributes(
                 Types.attributesNaturalLanguage.of(DEFAULT_LANGUAGE),
                 Types.attributesCharset.of(DEFAULT_CHARSET))
         }
@@ -150,29 +150,29 @@ data class IppPacket constructor(
             groups.findLast { it.tag == tag } ?: MutableAttributeGroup(tag).also { groups.add(it) }
 
         /** Get or create a group with [tag] and add or replace [attributes] in it. */
-        fun addAttributes(tag: Tag, attributes: List<Attribute<*>>) = this.apply {
+        fun putAttributes(tag: Tag, attributes: List<Attribute<*>>) = this.apply {
             getOrCreateGroup(tag) += attributes
         }
 
         /** Get or create a group with [tag] and add or replace [attributes] in it. */
-        fun addAttributes(tag: Tag, vararg attributes: Attribute<*>) =
-            addAttributes(tag, attributes.toList())
+        fun putAttributes(tag: Tag, vararg attributes: Attribute<*>) =
+            putAttributes(tag, attributes.toList())
 
         /** Get the [Tag.operationAttributes] group and add or replace [attributes] in it. */
-        fun addOperationAttributes(vararg attributes: Attribute<*>) =
-            addAttributes(Tag.operationAttributes, attributes.toList())
+        fun putOperationAttributes(vararg attributes: Attribute<*>) =
+            putAttributes(Tag.operationAttributes, attributes.toList())
 
         /** Get or create the [Tag.jobAttributes] group and add or replace [attributes] in it. */
-        fun addJobAttributes(vararg attributes: Attribute<*>) =
-            addAttributes(Tag.jobAttributes, attributes.toList())
+        fun putJobAttributes(vararg attributes: Attribute<*>) =
+            putAttributes(Tag.jobAttributes, attributes.toList())
 
         /** Get or create the [Tag.printerAttributes] group and add or replace [attributes] in it. */
-        fun addPrinterAttributes(vararg attributes: Attribute<*>) =
-            addAttributes(Tag.printerAttributes, attributes.toList())
+        fun putPrinterAttributes(vararg attributes: Attribute<*>) =
+            putAttributes(Tag.printerAttributes, attributes.toList())
 
         /** Get or create the [Tag.unsupportedAttributes] group and add or replace [attributes] in it. */
-        fun addUnsupportedAttributes(vararg attributes: Attribute<*>) =
-            addAttributes(Tag.unsupportedAttributes, attributes.toList())
+        fun putUnsupportedAttributes(vararg attributes: Attribute<*>) =
+            putAttributes(Tag.unsupportedAttributes, attributes.toList())
 
         /** Add a new [Tag.jobAttributes] group containing default attributes. */
         @JvmOverloads
@@ -235,13 +235,13 @@ data class IppPacket constructor(
             /** Printer attributes of interest. */
             vararg types: AttributeType<*>
         ) = Builder(Operation.getPrinterAttributes.code)
-            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
-            .attachRequestedAttributes(types.toList())
+            .putAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .putRequestedAttributes(types.toList())
 
         /** If supplied types are not empty, attach them as requested attributes. */
-        private fun Builder.attachRequestedAttributes(types: List<AttributeType<*>>) = this.apply {
+        private fun Builder.putRequestedAttributes(types: List<AttributeType<*>>) = this.apply {
             if (types.isNotEmpty()) {
-                addAttributes(Tag.operationAttributes,
+                putAttributes(Tag.operationAttributes,
                     Types.requestedAttributes.of(types.toList().map { it.name }))
             }
         }
@@ -251,21 +251,21 @@ data class IppPacket constructor(
         fun validateJob(
             printerUri: URI
         ) = Builder(Operation.validateJob.code)
-            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .putAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
 
         /** Return a Print-Job request [Builder]. */
         @JvmStatic
         fun printJob(
             printerUri: URI
         ) = Builder(code = Operation.printJob.code)
-            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .putAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
 
         /** Return a Create-Job request [Builder]. */
         @JvmStatic
         fun createJob(
             printerUri: URI
         ) = Builder(Operation.createJob.code)
-            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .putAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
 
         /** Return a Get-Jobs request [Builder]. */
         @JvmStatic
@@ -274,8 +274,8 @@ data class IppPacket constructor(
             /** Job attributes of interest. */
             vararg types: AttributeType<*>
         ) = Builder(Operation.getJobs.code)
-            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
-            .attachRequestedAttributes(types.toList())
+            .putAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .putRequestedAttributes(types.toList())
 
         /** Return a Send-Document request [Builder]. */
         @JvmStatic
@@ -283,7 +283,7 @@ data class IppPacket constructor(
             printerUri: URI,
             jobId: Int
         ) = Builder(Operation.sendDocument.code)
-            .addAttributes(Tag.operationAttributes,
+            .putAttributes(Tag.operationAttributes,
                 Types.printerUri.of(printerUri),
                 Types.jobId.of(jobId))
 
@@ -294,8 +294,8 @@ data class IppPacket constructor(
             /** Job attributes of interest. */
             vararg types: AttributeType<*>
         ) = Builder(Operation.sendDocument.code)
-            .addAttributes(Tag.operationAttributes, Types.jobUri.of(jobUri))
-            .attachRequestedAttributes(types.toList())
+            .putAttributes(Tag.operationAttributes, Types.jobUri.of(jobUri))
+            .putRequestedAttributes(types.toList())
 
         /** Return a Get-Job-Attributes request [Builder]. */
         @JvmStatic
@@ -305,10 +305,10 @@ data class IppPacket constructor(
             /** Job attributes of interest. */
             vararg types: AttributeType<*>
         ) = Builder(Operation.getJobAttributes.code)
-            .addAttributes(Tag.operationAttributes,
+            .putAttributes(Tag.operationAttributes,
                 Types.printerUri.of(printerUri),
                 Types.jobId.of(jobId))
-            .attachRequestedAttributes(types.toList())
+            .putRequestedAttributes(types.toList())
 
         /** Return a Get-Job-Attributes request [Builder]. */
         @JvmStatic
@@ -317,8 +317,8 @@ data class IppPacket constructor(
             /** Types of interest, if any. */
             vararg types: AttributeType<*>
         ) = Builder(Operation.getJobAttributes.code)
-            .addAttributes(Tag.operationAttributes, Types.jobUri.of(jobUri))
-            .attachRequestedAttributes(types.toList())
+            .putAttributes(Tag.operationAttributes, Types.jobUri.of(jobUri))
+            .putRequestedAttributes(types.toList())
 
         /** Return a Cancel-Job request [Builder]. */
         @JvmStatic
@@ -326,7 +326,7 @@ data class IppPacket constructor(
             printerUri: URI,
             jobId: Int
         ) = Builder(Operation.cancelJob.code)
-            .addAttributes(Tag.operationAttributes,
+            .putAttributes(Tag.operationAttributes,
                 Types.printerUri.of(printerUri),
                 Types.jobId.of(jobId))
 
@@ -335,7 +335,7 @@ data class IppPacket constructor(
         fun cancelJob(
             jobUri: URI
         ) = Builder(Operation.cancelJob.code)
-            .addAttributes(Tag.operationAttributes,
+            .putAttributes(Tag.operationAttributes,
                 Types.jobUri.of(jobUri))
 
         /** Return a generic response [Builder]. */
@@ -343,7 +343,7 @@ data class IppPacket constructor(
         fun response(
             status: Status
         ) = Builder(status.code)
-            .addAttributes(Tag.unsupportedAttributes)
+            .putAttributes(Tag.unsupportedAttributes)
 
         /** Return a job-related response packet [Builder]. */
         @JvmStatic
@@ -361,7 +361,7 @@ data class IppPacket constructor(
             /** A list of job-state-reasons, if any. */
             jobStateReasons: List<String> = listOf(JobStateReason.none)
         ) = Builder(status.code)
-            .addAttributes(Tag.unsupportedAttributes)
+            .putAttributes(Tag.unsupportedAttributes)
             .addJobAttributesGroup(jobId, jobUri, jobState, jobStateReasons)
     }
 }

--- a/jipp-core/src/main/java/com/hp/jipp/encoding/IppPacket.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/IppPacket.kt
@@ -3,12 +3,16 @@
 
 package com.hp.jipp.encoding
 
+import com.hp.jipp.model.JobState
+import com.hp.jipp.model.JobStateReason
 import com.hp.jipp.model.Operation
 import com.hp.jipp.model.Status
+import com.hp.jipp.model.Types
 import com.hp.jipp.util.PrettyPrinter
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.net.URI
 
 /**
  * An IPP packet consisting of header information and zero or more attribute groups.
@@ -96,9 +100,119 @@ data class IppPacket constructor(
         return prefix() + " " + attributeGroups
     }
 
+    class Builder
+    @JvmOverloads
+    constructor(
+        var code: Int,
+        var versionNumber: Int = DEFAULT_VERSION_NUMBER,
+        var requestId: Int = DEFAULT_REQUEST_ID
+    ) {
+        constructor(
+            status: Status,
+            versionNumber: Int = DEFAULT_VERSION_NUMBER,
+            requestId: Int = DEFAULT_REQUEST_ID
+        ) : this(status.code, versionNumber, requestId)
+
+        constructor(
+            operation: Operation,
+            versionNumber: Int = DEFAULT_VERSION_NUMBER,
+            requestId: Int = DEFAULT_REQUEST_ID
+        ) : this(operation.code, versionNumber, requestId)
+
+        private val groups: MutableList<MutableAttributeGroup> = mutableListOf()
+
+        init {
+            // All packets must have an operation attributes group with these initial attributes
+            addOperationAttributes(
+                Types.attributesNaturalLanguage.of(DEFAULT_LANGUAGE),
+                Types.attributesCharset.of(DEFAULT_CHARSET))
+        }
+
+        fun setVersionNumber(versionNumber: Int) = this.apply {
+            this.versionNumber = versionNumber
+        }
+
+        fun setRequestId(requestId: Int) = this.apply {
+            this.requestId = requestId
+        }
+
+        fun setCode(code: Int) = this.apply {
+            this.code = code
+        }
+
+        /** Append a new [AttributeGroup] after other groups. */
+        fun addGroup(group: AttributeGroup) = this.apply {
+            groups.add(group.toMutable())
+        }
+
+        /** Return the last group with the specified tag, creating it if necessary */
+        private fun getOrCreateGroup(tag: Tag) =
+            groups.findLast { it.tag == tag } ?: MutableAttributeGroup(tag).also { groups.add(it) }
+
+        /** Get or create a group with [tag] and add or replace [attributes] in it. */
+        fun addAttributes(tag: Tag, attributes: List<Attribute<*>>) = this.apply {
+            getOrCreateGroup(tag) += attributes
+        }
+
+        /** Get or create a group with [tag] and add or replace [attributes] in it. */
+        fun addAttributes(tag: Tag, vararg attributes: Attribute<*>) =
+            addAttributes(tag, attributes.toList())
+
+        /** Get the [Tag.operationAttributes] group and add or replace [attributes] in it. */
+        fun addOperationAttributes(vararg attributes: Attribute<*>) =
+            addAttributes(Tag.operationAttributes, attributes.toList())
+
+        /** Get or create the [Tag.jobAttributes] group and add or replace [attributes] in it. */
+        fun addJobAttributes(vararg attributes: Attribute<*>) =
+            addAttributes(Tag.jobAttributes, attributes.toList())
+
+        /** Get or create the [Tag.printerAttributes] group and add or replace [attributes] in it. */
+        fun addPrinterAttributes(vararg attributes: Attribute<*>) =
+            addAttributes(Tag.printerAttributes, attributes.toList())
+
+        /** Get or create the [Tag.unsupportedAttributes] group and add or replace [attributes] in it. */
+        fun addUnsupportedAttributes(vararg attributes: Attribute<*>) =
+            addAttributes(Tag.unsupportedAttributes, attributes.toList())
+
+        /** Add a new [Tag.jobAttributes] group containing default attributes. */
+        @JvmOverloads
+        fun addJobAttributesGroup(
+            /** The job-id to be used to identify this job in future requests. */
+            jobId: Int,
+            /** The job-uri to be used as a target for future requests. */
+            jobUri: URI,
+            /** The current job-state. */
+            jobState: JobState,
+            /** A list of job-state-reasons, if any. */
+            jobStateReasons: List<String> = listOf(JobStateReason.none),
+            /** Other job attributes, if any. */
+            vararg attributes: Attribute<*>
+        ) = this.apply {
+            addGroup(MutableAttributeGroup(Tag.jobAttributes, listOf(
+                Types.jobId.of(jobId),
+                Types.jobUri.of(jobUri),
+                Types.jobState.of(jobState),
+                Types.jobStateReasons.of(jobStateReasons)) + attributes.toList()))
+        }
+
+        /** Construct and return an [IppPacket] containing all settings given to this [Builder]. */
+        fun build() = IppPacket(versionNumber, code, requestId,
+            // Strip out any empty unsupported-attributes or job-attributes groups.
+            groups.filterNot { (it.tag == Tag.unsupportedAttributes || it.tag == Tag.jobAttributes) && it.isEmpty() })
+    }
+
     companion object {
         /** Default version number for IPP packets (0x200 for IPP 2.0) */
         const val DEFAULT_VERSION_NUMBER = 0x0200
+
+        /** Default request ID */
+        const val DEFAULT_REQUEST_ID = 1
+
+        /** Default language to use in operation groups. */
+        const val DEFAULT_LANGUAGE = "en-us"
+
+        /** Default charset to use in operation groups. */
+        const val DEFAULT_CHARSET = "utf-8"
 
         @JvmStatic
         @Throws(IOException::class)
@@ -113,5 +227,141 @@ data class IppPacket constructor(
             ReplaceWith("readPacket()", "com.hp.jipp.encoding.IppInputStream"))
         fun read(input: InputStream) =
             (input as? IppInputStream ?: IppInputStream(input)).readPacket()
+
+        /** Return a Get-Printer-Attributes request [Builder]. */
+        @JvmStatic
+        fun getPrinterAttributes(
+            printerUri: URI,
+            /** Printer attributes of interest. */
+            vararg types: AttributeType<*>
+        ) = Builder(Operation.getPrinterAttributes.code)
+            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .attachRequestedAttributes(types.toList())
+
+        /** If supplied types are not empty, attach them as requested attributes. */
+        private fun Builder.attachRequestedAttributes(types: List<AttributeType<*>>) = this.apply {
+            if (types.isNotEmpty()) {
+                addAttributes(Tag.operationAttributes,
+                    Types.requestedAttributes.of(types.toList().map { it.name }))
+            }
+        }
+
+        /** Return a Validate-Job request [Builder]. */
+        @JvmStatic
+        fun validateJob(
+            printerUri: URI
+        ) = Builder(Operation.validateJob.code)
+            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+
+        /** Return a Print-Job request [Builder]. */
+        @JvmStatic
+        fun printJob(
+            printerUri: URI
+        ) = Builder(code = Operation.printJob.code)
+            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+
+        /** Return a Create-Job request [Builder]. */
+        @JvmStatic
+        fun createJob(
+            printerUri: URI
+        ) = Builder(Operation.createJob.code)
+            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+
+        /** Return a Get-Jobs request [Builder]. */
+        @JvmStatic
+        fun getJobs(
+            printerUri: URI,
+            /** Job attributes of interest. */
+            vararg types: AttributeType<*>
+        ) = Builder(Operation.getJobs.code)
+            .addAttributes(Tag.operationAttributes, Types.printerUri.of(printerUri))
+            .attachRequestedAttributes(types.toList())
+
+        /** Return a Send-Document request [Builder]. */
+        @JvmStatic
+        fun sendDocument(
+            printerUri: URI,
+            jobId: Int
+        ) = Builder(Operation.sendDocument.code)
+            .addAttributes(Tag.operationAttributes,
+                Types.printerUri.of(printerUri),
+                Types.jobId.of(jobId))
+
+        /** Return a Send-Document request [Builder] */
+        @JvmStatic
+        fun sendDocument(
+            jobUri: URI,
+            /** Job attributes of interest. */
+            vararg types: AttributeType<*>
+        ) = Builder(Operation.sendDocument.code)
+            .addAttributes(Tag.operationAttributes, Types.jobUri.of(jobUri))
+            .attachRequestedAttributes(types.toList())
+
+        /** Return a Get-Job-Attributes request [Builder]. */
+        @JvmStatic
+        fun getJobAttributes(
+            printerUri: URI,
+            jobId: Int,
+            /** Job attributes of interest. */
+            vararg types: AttributeType<*>
+        ) = Builder(Operation.getJobAttributes.code)
+            .addAttributes(Tag.operationAttributes,
+                Types.printerUri.of(printerUri),
+                Types.jobId.of(jobId))
+            .attachRequestedAttributes(types.toList())
+
+        /** Return a Get-Job-Attributes request [Builder]. */
+        @JvmStatic
+        fun getJobAttributes(
+            jobUri: URI,
+            /** Types of interest, if any. */
+            vararg types: AttributeType<*>
+        ) = Builder(Operation.getJobAttributes.code)
+            .addAttributes(Tag.operationAttributes, Types.jobUri.of(jobUri))
+            .attachRequestedAttributes(types.toList())
+
+        /** Return a Cancel-Job request [Builder]. */
+        @JvmStatic
+        fun cancelJob(
+            printerUri: URI,
+            jobId: Int
+        ) = Builder(Operation.cancelJob.code)
+            .addAttributes(Tag.operationAttributes,
+                Types.printerUri.of(printerUri),
+                Types.jobId.of(jobId))
+
+        /** Return a Cancel-Job request [Builder]. */
+        @JvmStatic
+        fun cancelJob(
+            jobUri: URI
+        ) = Builder(Operation.cancelJob.code)
+            .addAttributes(Tag.operationAttributes,
+                Types.jobUri.of(jobUri))
+
+        /** Return a generic response [Builder]. */
+        @JvmStatic
+        fun response(
+            status: Status
+        ) = Builder(status.code)
+            .addAttributes(Tag.unsupportedAttributes)
+
+        /** Return a job-related response packet [Builder]. */
+        @JvmStatic
+        @JvmOverloads
+        @Suppress("LongParameterList") // All of these parameters required in Job responses.
+        fun jobResponse(
+            /** The status code for the request. */
+            status: Status,
+            /** The job-id to be used to identify this job in future requests. */
+            jobId: Int,
+            /** The job-uri to be used as a target for future requests. */
+            jobUri: URI,
+            /** The current job-state. */
+            jobState: JobState,
+            /** A list of job-state-reasons, if any. */
+            jobStateReasons: List<String> = listOf(JobStateReason.none)
+        ) = Builder(status.code)
+            .addAttributes(Tag.unsupportedAttributes)
+            .addJobAttributesGroup(jobId, jobUri, jobState, jobStateReasons)
     }
 }

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeGroupTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeGroupTest.java
@@ -69,7 +69,7 @@ public class AttributeGroupTest {
         IppPacket packet = IppPacket.jobResponse(Status.successfulOk, 1, URI.create("ipp://10.0.0.23/ipp/printer/job/1"),
                 JobState.pending,
                 Collections.singletonList(JobStateReason.accountClosed))
-                .addAttributes(operationAttributes, Types.printerUri.of(URI.create("ipp://10.0.0.23/ipp/printer")))
+                .putAttributes(operationAttributes, Types.printerUri.of(URI.create("ipp://10.0.0.23/ipp/printer")))
                 .build();
         packet = cycle(packet);
         AttributeGroup group = packet.get(operationAttributes);

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeGroupTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeGroupTest.java
@@ -1,6 +1,9 @@
 package com.hp.jipp.encoding;
 
 import com.hp.jipp.model.DocumentState;
+import com.hp.jipp.model.JobState;
+import com.hp.jipp.model.JobStateReason;
+import com.hp.jipp.model.Status;
 import com.hp.jipp.model.Types;
 import com.hp.jipp.util.BuildError;
 import java.io.IOException;
@@ -11,12 +14,10 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 
-import static com.hp.jipp.encoding.AttributeGroup.groupOf;
-import static com.hp.jipp.encoding.AttributeGroup.mutableGroupOf;
+import static com.hp.jipp.encoding.AttributeGroup.*;
 import static com.hp.jipp.encoding.Cycler.coverList;
 import static com.hp.jipp.encoding.Cycler.cycle;
-import static com.hp.jipp.encoding.Tag.operationAttributes;
-import static com.hp.jipp.encoding.Tag.printerAttributes;
+import static com.hp.jipp.encoding.Tag.*;
 import static junit.framework.TestCase.assertTrue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
@@ -64,9 +65,38 @@ public class AttributeGroupTest {
     }
 
     @Test
+    public void operationGroupWithUri() throws Exception {
+        IppPacket packet = IppPacket.jobResponse(Status.successfulOk, 1, URI.create("ipp://10.0.0.23/ipp/printer/job/1"),
+                JobState.pending,
+                Collections.singletonList(JobStateReason.accountClosed))
+                .addAttributes(operationAttributes, Types.printerUri.of(URI.create("ipp://10.0.0.23/ipp/printer")))
+                .build();
+        packet = cycle(packet);
+        AttributeGroup group = packet.get(operationAttributes);
+        assertEquals(group.getTag(), operationAttributes);
+        assertNotNull(group.get(Types.attributesCharset));
+        assertNotNull(group.get(Types.attributesNaturalLanguage));
+        assertNotNull(group.get(Types.printerUri));
+        AttributeGroup jobGroup = packet.get(jobAttributes);
+        assertNotNull(jobGroup.get(Types.jobUri));
+        assertNotNull(jobGroup.get(Types.jobId));
+        assertEquals(Collections.singletonList(JobStateReason.accountClosed), jobGroup.get(Types.jobStateReasons));
+    }
+
+    @Test
+    public void multipleJobGroups() throws Exception {
+        IppPacket packet = IppPacket.jobResponse(Status.successfulOk, 1, URI.create("ipp://10.0.0.23/ipp/printer/job/1"),
+                JobState.pending)
+                .addJobAttributesGroup(1, URI.create("ipp://10.0.0.23/ipp/printer/job/2"), JobState.aborted)
+                .build();
+        packet = cycle(packet);
+        assertEquals(Tag.jobAttributes, packet.getAttributeGroups().get(2).getTag());
+    }
+
+    @Test
     public void multiMultiAttribute() throws Exception {
         AttributeGroup group = cycle(groupOf(operationAttributes,
-                Types.attributesCharset.of("utf-8","utf-16")));
+                Types.attributesCharset.of("utf-8", "utf-16")));
         assertEquals(Arrays.asList("utf-8", "utf-16"), group.get(Types.attributesCharset).strings());
     }
 
@@ -160,8 +190,18 @@ public class AttributeGroupTest {
         assertEquals(mutableGroup, group);
         assertEquals(group, group.toMutable());
 
-        mutableGroup.add(Types.requestingUserName.of("test"));
+        mutableGroup.put(Types.requestingUserName.of("test"));
         assertNotEquals(group, mutableGroup);
+    }
+
+    @Test
+    public void mutableAddMultiple() throws Exception {
+        MutableAttributeGroup mutableGroup = mutableGroupOf(operationAttributes,
+                Types.attributesCharset.of("utf-8", "utf-16"));
+        mutableGroup.put(Types.attributesCharset.of("utf-8", "utf-16"),
+                Types.attributesNaturalLanguage.of("sp"));
+        assertEquals("sp", mutableGroup.getValue(Types.attributesNaturalLanguage));
+        assertEquals(Arrays.asList("utf-8", "utf-16"), mutableGroup.getValues(Types.attributesCharset));
     }
 
     @Test
@@ -172,20 +212,20 @@ public class AttributeGroupTest {
         assertEquals(0, mutableGroup.indexOf(Types.attributesCharset.of("utf-8")));
 
         Attribute<Name> printerName = Types.printerName.of("myprinter");
-        mutableGroup.attr(Types.printerName.of(new Name("myprinter")));
+        mutableGroup.put(Types.printerName.of(new Name("myprinter")));
         assertEquals(1, mutableGroup.lastIndexOf(printerName));
         assertEquals(printerName, mutableGroup.get(Types.printerName));
 
         mutableGroup.plusAssign(Collections.singletonList(printerName));
         assertEquals(printerName, mutableGroup.get(Types.printerName.getName()));
 
-        mutableGroup.attr(Types.printerName, "first", "second");
+        mutableGroup.put(Types.printerName, "first", "second");
         assertEquals(Types.printerName.of("first", "second"), mutableGroup.get(Types.printerName));
 
-        mutableGroup.attr(Types.printerName, new Name("third"), new Name("fourth"));
+        mutableGroup.put(Types.printerName, new Name("third"), new Name("fourth"));
         assertEquals(Types.printerName.of("third", "fourth"), mutableGroup.get(Types.printerName));
 
-        mutableGroup.attr(Types.printerOrganization, "mine", "still mine");
+        mutableGroup.put(Types.printerOrganization, "mine", "still mine");
         assertEquals(Types.printerOrganization.of("mine", "still mine"), mutableGroup.get(Types.printerOrganization));
 
         assertNull(mutableGroup.get(Types.documentFormat.getName()));
@@ -201,10 +241,24 @@ public class AttributeGroupTest {
         assertFalse(mutableGroup.drop(printerName)); // Not there anymore
 
         // Put it back and drop it again
-        mutableGroup.add(printerName);
+        mutableGroup.put(printerName);
         assertTrue(mutableGroup.drop(printerName));
         assertFalse(mutableGroup.drop(printerName));
     }
+
+    @Test
+    public void minus() throws Exception {
+        Attribute<Name> printerName = Types.printerName.of("jim");
+        MutableAttributeGroup mutableGroup = mutableGroupOf(printerAttributes, printerName);
+        mutableGroup.minusAssign(Types.printerName);
+        assertNull(mutableGroup.get(Types.printerName));
+
+        mutableGroup.put(printerName);
+        assertNotNull(mutableGroup.get(Types.printerName));
+        mutableGroup.minusAssign(printerName);
+        assertNull(mutableGroup.get(Types.printerName));
+    }
+
 
     @Test
     public void cycleMutableGroup() throws Exception {

--- a/jipp-core/src/test/java/com/hp/jipp/model/DeprecatedTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/model/DeprecatedTest.java
@@ -1,0 +1,69 @@
+package com.hp.jipp.model;
+
+import com.hp.jipp.encoding.Attribute;
+import com.hp.jipp.encoding.IppInputStream;
+import com.hp.jipp.encoding.IppPacket;
+import com.hp.jipp.encoding.MutableAttributeGroup;
+import com.hp.jipp.encoding.Name;
+import com.hp.jipp.encoding.Tag;
+import java.util.Collections;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static com.hp.jipp.encoding.AttributeGroup.groupOf;
+import static com.hp.jipp.encoding.AttributeGroup.mutableGroupOf;
+import static com.hp.jipp.encoding.Tag.operationAttributes;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@SuppressWarnings("deprecation")
+public class DeprecatedTest {
+    IppPacket packet = new IppPacket(0x0102, Operation.holdJob.getCode(), 0x50607,
+            groupOf(Tag.printerAttributes, Types.operationsSupported.of(Operation.createJob)));
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    @Test
+    public void parseFromInputStream() throws IOException {
+        packet.write(out);
+        IppPacket readPacket = IppPacket.parse(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(packet, readPacket);
+    }
+
+    @Test
+    public void parseFromIppInputStream() throws IOException {
+        packet.write(out);
+        IppPacket readPacket = IppPacket.parse(new IppInputStream(new ByteArrayInputStream(out.toByteArray())));
+        assertEquals(packet, readPacket);
+        readPacket = IppPacket.read(new IppInputStream(new ByteArrayInputStream(out.toByteArray())));
+        assertEquals(packet, readPacket);
+    }
+
+    @Test
+    public void readFromInputStream() throws IOException {
+        packet.write(out);
+        IppPacket readPacket = IppPacket.read(new ByteArrayInputStream(out.toByteArray()));
+        assertEquals(packet, readPacket);
+    }
+
+    @Test
+    public void mutableGroupAccessors() {
+        MutableAttributeGroup mutableGroup = mutableGroupOf(operationAttributes);
+        Attribute<Name> printerName = Types.printerName.of("myprinter");
+        mutableGroup.add(Types.printerName.of(new Name("myprinter")));
+        assertEquals(0, mutableGroup.lastIndexOf(printerName));
+        assertEquals(printerName, mutableGroup.get(Types.printerName));
+
+        mutableGroup.addAll(1, Collections.singletonList(Types.documentName.of("mydocument")));
+        assertEquals("mydocument", mutableGroup.getValue(Types.documentName).asString());
+
+        mutableGroup.add(1, Types.documentName.of("mydocument2"));
+        assertEquals("mydocument2", mutableGroup.getValue(Types.documentName).asString());
+
+        mutableGroup.add(Types.printerDnsSdName.of("myprinter"), Types.printerFaxModemName.of("mymodem"));
+        assertEquals("myprinter", mutableGroup.getValue(Types.printerDnsSdName).asString());
+        assertEquals("mymodem", mutableGroup.getValue(Types.printerFaxModemName).asString());
+    }
+}

--- a/jipp-core/src/test/kotlin/com/hp/jipp/dsl/DslTest.kt
+++ b/jipp-core/src/test/kotlin/com/hp/jipp/dsl/DslTest.kt
@@ -2,6 +2,8 @@ package com.hp.jipp.dsl
 
 import com.hp.jipp.encoding.Cycler.cycle
 import com.hp.jipp.encoding.IntOrIntRange
+import com.hp.jipp.encoding.IppPacket
+import com.hp.jipp.encoding.IppPacket.Companion.DEFAULT_REQUEST_ID
 import com.hp.jipp.encoding.MediaSizes
 import com.hp.jipp.encoding.Name
 import com.hp.jipp.encoding.Tag
@@ -21,6 +23,26 @@ class DslTest {
     private val mediaSize = MediaSizes.parse(Media.naLetter8p5x11in)!!
 
     @Test
+    fun `java-style build`() {
+        val packet = IppPacket.printJob(uri)
+            .addOperationAttributes(Types.requestingUserName.of("Test User"))
+            .addJobAttributes(Types.mediaCol.of(MediaCol(mediaSize = mediaSize)),
+                Types.documentMessage.of("A description of the document"))
+            .addPrinterAttributes(Types.bindingTypeSupported.of(BindingType.adhesive))
+            .addUnsupportedAttributes(Types.outputBin.noValue())
+            .build()
+
+        val cycled = cycle(packet)
+
+        assertEquals("utf-8", cycled.getValue(Tag.operationAttributes, Types.attributesCharset))
+        assertEquals(mediaSize, cycled.getValue(Tag.jobAttributes, Types.mediaCol)!!.mediaSize)
+        assertEquals(listOf(BindingType.adhesive), cycled.getValues(Tag.printerAttributes, Types.bindingTypeSupported))
+        assertEquals(Types.outputBin.noValue(), cycled[Tag.unsupportedAttributes]?.get(Types.outputBin))
+        assertEquals("A description of the document", cycled[Tag.jobAttributes]?.getValue(Types.documentMessage)?.value)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
     fun packetTest() {
         val packet = ippPacket(Operation.printJob) {
             operationAttributes {
@@ -51,16 +73,15 @@ class DslTest {
 
     @Test
     fun intOrIntRange() {
-        val packet = ippPacket(Status.successfulOk) {
-            group(Tag.printerAttributes) {
-                attr(Types.numberUpSupported, IntOrIntRange(5..6))
-            }
-        }
+        val packet = IppPacket.response(Status.successfulOk)
+            .addPrinterAttributes(Types.numberUpSupported.of(5..6))
+            .build()
         Assert.assertNotEquals(listOf<IntOrIntRange>(),
             packet.getValues(Tag.printerAttributes, Types.numberUpSupported))
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `extend a group`() {
         val packet = ippPacket(Operation.printJob) {
             // We can get and set the status if we want to
@@ -92,6 +113,7 @@ class DslTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `modify a group`() {
         val packet = ippPacket(Operation.printJob) {
             // We can get and set the status if we want to
@@ -125,46 +147,53 @@ class DslTest {
 
     @Test
     fun `extend a non-existent group`() {
-        val packet = ippPacket(Operation.printJob) {
+        val packet = IppPacket.printJob(uri)
             // Extend a tag that's not there
-            extend(Tag.printerAttributes) {
-                attr(Types.jobAccountId, "25")
-            }
-        }
+            .addPrinterAttributes(Types.jobAccountId.of("25"))
+            .build()
+
         assertEquals(Name("25"), packet.getValue(Tag.printerAttributes, Types.jobAccountId))
     }
 
     @Test
-    fun `add a group`() {
-        val operationGroup = group(Tag.operationAttributes) {
-            attr(Types.attributesNaturalLanguage, "en")
-        }
-        val packet = ippPacket(Operation.printJob) {
-            group(operationGroup)
-        }
-        assertEquals("en", packet.getValue(Tag.operationAttributes, Types.attributesNaturalLanguage))
-    }
-
-    @Test
     fun `mess with packet fields`() {
-        val packet = ippPacket(Operation.printJob) {
-            operationAttributes { }
-            if (operation == Operation.printJob) {
-                operation = Operation.createJob
-            }
+        val packet = IppPacket.printJob(uri).apply {
+            code = Operation.createJob.code
             versionNumber = 2000
             requestId++
-        }
+        }.build()
+
         assertEquals(Operation.createJob, packet.operation)
         assertEquals(2000, packet.versionNumber)
-        assertEquals(ippPacket.DEFAULT_REQUEST_ID + 1, packet.requestId)
+        assertEquals(DEFAULT_REQUEST_ID + 1, packet.requestId)
     }
 
     @Test
-    fun `set packet code directly`() {
-        val packet = ippPacket(Operation.printJob) {
-            code = Operation.createJob.code
-        }
+    fun `mess with packet fields via builders`() {
+        val packet = IppPacket.printJob(uri)
+            .setCode(Operation.createJob.code)
+            .setVersionNumber(2000)
+            .setRequestId(101)
+            .build()
+
         assertEquals(Operation.createJob, packet.operation)
+        assertEquals(2000, packet.versionNumber)
+        assertEquals(101, packet.requestId)
+    }
+
+    @Test
+    fun `construct with status`() {
+        val packet = IppPacket.Builder(Status.successfulOk, 2000, 101)
+            .build()
+
+        assertEquals(Status.successfulOk, packet.status)
+        assertEquals(2000, packet.versionNumber)
+        assertEquals(101, packet.requestId)
+    }
+
+    @Test
+    fun `construct with operation`() {
+        val packet = IppPacket.Builder(Operation.fetchJob).build()
+        assertEquals(Operation.fetchJob, packet.operation)
     }
 }

--- a/jipp-core/src/test/kotlin/com/hp/jipp/dsl/DslTest.kt
+++ b/jipp-core/src/test/kotlin/com/hp/jipp/dsl/DslTest.kt
@@ -25,11 +25,11 @@ class DslTest {
     @Test
     fun `java-style build`() {
         val packet = IppPacket.printJob(uri)
-            .addOperationAttributes(Types.requestingUserName.of("Test User"))
-            .addJobAttributes(Types.mediaCol.of(MediaCol(mediaSize = mediaSize)),
+            .putOperationAttributes(Types.requestingUserName.of("Test User"))
+            .putJobAttributes(Types.mediaCol.of(MediaCol(mediaSize = mediaSize)),
                 Types.documentMessage.of("A description of the document"))
-            .addPrinterAttributes(Types.bindingTypeSupported.of(BindingType.adhesive))
-            .addUnsupportedAttributes(Types.outputBin.noValue())
+            .putPrinterAttributes(Types.bindingTypeSupported.of(BindingType.adhesive))
+            .putUnsupportedAttributes(Types.outputBin.noValue())
             .build()
 
         val cycled = cycle(packet)
@@ -74,7 +74,7 @@ class DslTest {
     @Test
     fun intOrIntRange() {
         val packet = IppPacket.response(Status.successfulOk)
-            .addPrinterAttributes(Types.numberUpSupported.of(5..6))
+            .putPrinterAttributes(Types.numberUpSupported.of(5..6))
             .build()
         Assert.assertNotEquals(listOf<IntOrIntRange>(),
             packet.getValues(Tag.printerAttributes, Types.numberUpSupported))
@@ -149,7 +149,7 @@ class DslTest {
     fun `extend a non-existent group`() {
         val packet = IppPacket.printJob(uri)
             // Extend a tag that's not there
-            .addPrinterAttributes(Types.jobAccountId.of("25"))
+            .putPrinterAttributes(Types.jobAccountId.of("25"))
             .build()
 
         assertEquals(Name("25"), packet.getValue(Tag.printerAttributes, Types.jobAccountId))

--- a/sample/jprint/src/main/java/sample/Main.java
+++ b/sample/jprint/src/main/java/sample/Main.java
@@ -2,7 +2,6 @@ package sample;
 
 import com.hp.jipp.encoding.Attribute;
 import com.hp.jipp.encoding.IppPacket;
-import com.hp.jipp.encoding.Tag;
 import com.hp.jipp.model.Types;
 import com.hp.jipp.trans.IppClientTransport;
 import com.hp.jipp.trans.IppPacketData;
@@ -82,7 +81,7 @@ class Main {
         }
 
         IppPacket attributeRequest = IppPacket.getPrinterAttributes(uri)
-                .addOperationAttributes(requestingUserName.of(CMD_NAME), requested)
+                .putOperationAttributes(requestingUserName.of(CMD_NAME), requested)
                 .build();
 
         System.out.println("Sending " + attributeRequest.prettyPrint(100, "  "));
@@ -102,7 +101,7 @@ class Main {
 
         // Query for supported document formats
         IppPacket attributeRequest = IppPacket.getPrinterAttributes(uri)
-                .addOperationAttributes(
+                .putOperationAttributes(
                         requestingUserName.of(CMD_NAME),
                         requestedAttributes.of(documentFormatSupported.getName()))
                 .build();
@@ -120,7 +119,7 @@ class Main {
 
         // Deliver the print request
         IppPacket printRequest = IppPacket.printJob(uri)
-                .addOperationAttributes(
+                .putOperationAttributes(
                         requestingUserName.of("jprint"),
                         documentFormat.of(format))
                 .build();

--- a/sample/jprint/src/main/java/sample/Main.java
+++ b/sample/jprint/src/main/java/sample/Main.java
@@ -3,11 +3,9 @@ package sample;
 import com.hp.jipp.encoding.Attribute;
 import com.hp.jipp.encoding.IppPacket;
 import com.hp.jipp.encoding.Tag;
-import com.hp.jipp.model.Operation;
 import com.hp.jipp.model.Types;
 import com.hp.jipp.trans.IppClientTransport;
 import com.hp.jipp.trans.IppPacketData;
-import org.apache.commons.cli.BasicParser;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.DefaultParser;
@@ -21,11 +19,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 
-import static com.hp.jipp.encoding.AttributeGroup.groupOf;
-import static com.hp.jipp.encoding.Tag.*;
+import static com.hp.jipp.encoding.Tag.printerAttributes;
 import static com.hp.jipp.model.Types.*;
 
 class Main {
@@ -85,13 +81,9 @@ class Main {
             requested = requestedAttributes.of("all");
         }
 
-        IppPacket attributeRequest = new IppPacket(Operation.getPrinterAttributes, 1,
-                groupOf(operationAttributes,
-                        attributesCharset.of("utf-8"),
-                        attributesNaturalLanguage.of("en"),
-                        printerUri.of(uri),
-                        requestingUserName.of("jprint"),
-                        requested));
+        IppPacket attributeRequest = IppPacket.getPrinterAttributes(uri)
+                .addOperationAttributes(requestingUserName.of(CMD_NAME), requested)
+                .build();
 
         System.out.println("Sending " + attributeRequest.prettyPrint(100, "  "));
         IppPacketData request = new IppPacketData(attributeRequest);
@@ -109,13 +101,11 @@ class Main {
         System.out.println("File is " + inputFile);
 
         // Query for supported document formats
-        IppPacket attributeRequest = new IppPacket(Operation.getPrinterAttributes, 1,
-                groupOf(operationAttributes,
-                        attributesCharset.of("utf-8"),
-                        attributesNaturalLanguage.of("en"),
-                        printerUri.of(uri),
+        IppPacket attributeRequest = IppPacket.getPrinterAttributes(uri)
+                .addOperationAttributes(
                         requestingUserName.of(CMD_NAME),
-                        requestedAttributes.of(documentFormatSupported.getName())));
+                        requestedAttributes.of(documentFormatSupported.getName()))
+                .build();
 
         System.out.println("Sending " + attributeRequest.prettyPrint(100, "  "));
         IppPacketData request = new IppPacketData(attributeRequest);
@@ -129,13 +119,11 @@ class Main {
         }
 
         // Deliver the print request
-        IppPacket printRequest = new IppPacket(Operation.printJob, 2,
-                groupOf(operationAttributes,
-                        attributesCharset.of("utf-8"),
-                        attributesNaturalLanguage.of("en"),
-                        printerUri.of(uri),
+        IppPacket printRequest = IppPacket.printJob(uri)
+                .addOperationAttributes(
                         requestingUserName.of("jprint"),
-                        documentFormat.of(format)));
+                        documentFormat.of(format))
+                .build();
 
         System.out.println("Sending " + printRequest.prettyPrint(100, "  "));
         request = new IppPacketData(printRequest, new FileInputStream(inputFile));


### PR DESCRIPTION
Fix #77 with the implementation of IppPacket builders. These builders enforce the presence of all MUST attributes.

Must the `requesting-user-name` appear before other attributes for some printer models?