### PR TITLE
Allow IppOutputstream to be used for serializing single attributes and groups

### DIFF
--- a/jipp-core/src/main/java/com/hp/jipp/encoding/IppOutputStream.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/encoding/IppOutputStream.kt
@@ -47,13 +47,13 @@ class IppOutputStream(outputStream: OutputStream) : DataOutputStream(outputStrea
     }
 
     /** Write [group] to this stream. */
-    private fun write(group: AttributeGroup) {
+    fun write(group: AttributeGroup) {
         write(group.tag)
         group.forEach { write(it) }
     }
 
     /** Write [attribute] to this stream. */
-    private fun write(attribute: Attribute<*>, name: String = attribute.name) {
+    fun write(attribute: Attribute<*>, name: String = attribute.name) {
         val type = attribute.type
         if (type is EmptyAttributeType) {
             // Write the out-of-band tag


### PR DESCRIPTION
Registering virtual printers in Microsoft universal Print, requires you to send an ipp payload consisting only of an attribute group
(see: Print https://docs.microsoft.com/en-us/graph/api/printer-update?view=graph-rest-beta&tabs=http ).
There doesn't currently appear to be a way to generate such a payload using jipp (let me know if I'm wrong). 
This pull request simply makes public the relevant functions on the IppOutputStream. I included the "write(attribute: Attribute<*>, name: String = attribute.name)" function, purely for consistency, it's not technically required.