### PR TITLE
handle sonatype Vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-    ext.kotlin_version = '1.5.21'
+    ext.kotlin_version = '1.9.10'
     ext.ktlint_version = '0.41.0'
 
     // Version of JIPP & friends to publish
@@ -16,9 +16,9 @@ allprojects {
 
         dependencies {
             classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-            classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.4.30"
+            classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.9.0"
             classpath "gradle.plugin.pl.squirrel:classycle-gradle-plugin:1.2"
-            classpath "org.jlleitschuh.gradle:ktlint-gradle:10.1.0"
+            classpath "org.jlleitschuh.gradle:ktlint-gradle:11.6.0"
             classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.14.1"
         }
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/jipp-core/build.gradle
+++ b/jipp-core/build.gradle
@@ -56,13 +56,13 @@ test {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.9"
 }
 
 jacocoTestReport {
     reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
-        html.enabled = true
+        xml.required = true // coveralls plugin depends on xml format report
+        html.outputLocation = layout.buildDirectory.dir('reports/jacocoHtml')
     }
 
     afterEvaluate {

--- a/jipp-pdl/build.gradle
+++ b/jipp-pdl/build.gradle
@@ -40,13 +40,13 @@ afterEvaluate {
 test.finalizedBy jacocoTestReport
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.9"
 }
 
 jacocoTestReport {
     reports {
-        xml.enabled = true // coveralls plugin depends on xml format report
-        html.enabled = true
+        xml.required = true // coveralls plugin depends on xml format report
+        html.outputLocation = layout.buildDirectory.dir('reports/jacocoHtml')
     }
 
     afterEvaluate {


### PR DESCRIPTION
Sonatype reported a vulnerability in last build [Sonatype report](https://sbom.sonatype.com/report/T1-118f0f57da8c6b3097cc-3badd4c7429913-1695141489-184118e19e9045309de9991ebd9c5de7)

issue pointed: [CVE-2022-24329](https://ossindex.sonatype.org/vulnerability/CVE-2022-24329?component-type=maven&component-name=org.jetbrains.kotlin%2Fkotlin-stdlib&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0) 

Updated dependencies:

- kotlin-gradle-plugin
- dokka-gradle-plugin
- ktlint-gradle

other upgrades:
- jacoco toolversion
- gradle wrapper
