### PR TITLE
180: Fix spec spelling mistake for DocumentState enum

### DIFF
--- a/jipp-core/src/main/java/com/hp/jipp/model/DocumentState.kt
+++ b/jipp-core/src/main/java/com/hp/jipp/model/DocumentState.kt
@@ -26,7 +26,7 @@ data class DocumentState(override val code: Int, override val name: String) : En
 
     object Code {
         const val pending = 3
-        const val procesing = 5
+        const val processing = 5
         const val processingStopped = 6
         const val canceled = 7
         const val aborted = 8
@@ -35,7 +35,7 @@ data class DocumentState(override val code: Int, override val name: String) : En
 
     companion object {
         @JvmField val pending = DocumentState(Code.pending, "pending")
-        @JvmField val procesing = DocumentState(Code.procesing, "procesing")
+        @JvmField val processing = DocumentState(Code.processing, "processing")
         @JvmField val processingStopped = DocumentState(Code.processingStopped, "processing-stopped")
         @JvmField val canceled = DocumentState(Code.canceled, "canceled")
         @JvmField val aborted = DocumentState(Code.aborted, "aborted")
@@ -43,7 +43,7 @@ data class DocumentState(override val code: Int, override val name: String) : En
 
         @JvmField val all = listOf(
             pending,
-            procesing,
+            processing,
             processingStopped,
             canceled,
             aborted,

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeGroupTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeGroupTest.java
@@ -62,7 +62,7 @@ public class AttributeGroupTest {
         DocumentState.Type documentStateType = new DocumentState.Type("document-state");
 
         assertEquals(Arrays.asList(
-                DocumentState.pending, DocumentState.procesing, DocumentState.processingStopped
+                DocumentState.pending, DocumentState.processing, DocumentState.processingStopped
         ), group.get(documentStateType));
     }
 

--- a/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeTest.java
+++ b/jipp-core/src/test/java/com/hp/jipp/encoding/AttributeTest.java
@@ -46,7 +46,7 @@ public class AttributeTest {
         UnknownAttribute intAttr = new UnknownAttribute("document-state", new UntypedEnum(3), new UntypedEnum(5), new UntypedEnum(6));
         DocumentState.Type documentStateType = new DocumentState.Type("document-state");
         assertEquals(Arrays.asList(
-                DocumentState.pending, DocumentState.procesing, DocumentState.processingStopped
+                DocumentState.pending, DocumentState.processing, DocumentState.processingStopped
         ), documentStateType.coerce(intAttr));
     }
 


### PR DESCRIPTION
Fix #180 
Change:

- Fix spelling mistake from procesing to processing
- Fix usage in unit test